### PR TITLE
Update 1-Initiation-RDD.ipynb

### DIFF
--- a/2-novice/1-Initiation-RDD.ipynb
+++ b/2-novice/1-Initiation-RDD.ipynb
@@ -823,7 +823,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.parallelize(range(10)).map(lambda num: (num, 1)).reduceByKey(lambda x,y: x+y).collect()"
+    "sc.parallelize(range(10)).map(lambda num: (num % 2, num)).reduceByKey(lambda x,y: x+y).collect()"
    ]
   },
   {


### PR DESCRIPTION
Changed reduceByKey example.

Previously, the lambda num: (num, 1) produced all unique keys, so the functionality of reduceByKey couldn't be appreciated.

I changed it to lambda num: (num % 2, num), so we could see what happened to keys 0 and 1.